### PR TITLE
refactor : pageList를 planList, eventList로 이름 변경, plan api 수정, EventPagingResult 이름 변경

### DIFF
--- a/src/main/java/seoultech/startapp/event/adapter/in/EventAdminController.java
+++ b/src/main/java/seoultech/startapp/event/adapter/in/EventAdminController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import seoultech.startapp.event.application.EventPagingResult;
+import seoultech.startapp.event.application.EventPagingResponse;
 import seoultech.startapp.event.application.port.in.EventCommand;
 import seoultech.startapp.event.application.port.in.EventGetUseCase;
 import seoultech.startapp.event.application.port.in.EventRegisterUseCase;
@@ -33,7 +33,7 @@ class EventAdminController {
     public ResponseEntity<?> getAllEventByPaging(@RequestParam int page, @RequestParam(defaultValue = "10",required = false) int count){
 
 
-        EventPagingResult pageEvents = eventGetUseCase.getAllEventByPaging(page,count);
+        EventPagingResponse pageEvents = eventGetUseCase.getAllEventByPaging(page, count);
 
         return JsonResponse.okWithData(HttpStatus.OK,"페이지에 해당하는 이벤트를 찾았습니다.",pageEvents);
     }

--- a/src/main/java/seoultech/startapp/event/application/EventGetService.java
+++ b/src/main/java/seoultech/startapp/event/application/EventGetService.java
@@ -39,11 +39,11 @@ class EventGetService implements EventGetUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public EventPagingResult getAllEventByPaging(int page, int count) {
+    public EventPagingResponse getAllEventByPaging(int page, int count) {
 
         Page<EventResponse> eventResponses = loadEventPort.loadAllEventByPaging(PageRequest.of(page,count))
                                                .map(EventResponse::eventToEventResponse);
 
-        return new EventPagingResult(eventResponses.getTotalPages(),eventResponses.getContent());
+        return new EventPagingResponse(eventResponses.getTotalPages(), eventResponses.getContent());
     }
 }

--- a/src/main/java/seoultech/startapp/event/application/EventPagingResponse.java
+++ b/src/main/java/seoultech/startapp/event/application/EventPagingResponse.java
@@ -9,10 +9,10 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class EventPagingResult {
+public class EventPagingResponse {
 
     private int totalPage;
 
-    private List<EventResponse> pageList;
+    private List<EventResponse> eventList;
 
 }

--- a/src/main/java/seoultech/startapp/event/application/port/in/EventGetUseCase.java
+++ b/src/main/java/seoultech/startapp/event/application/port/in/EventGetUseCase.java
@@ -1,6 +1,6 @@
 package seoultech.startapp.event.application.port.in;
 
-import seoultech.startapp.event.application.EventPagingResult;
+import seoultech.startapp.event.application.EventPagingResponse;
 import seoultech.startapp.event.application.EventResponse;
 
 import java.util.List;
@@ -11,5 +11,5 @@ public interface EventGetUseCase {
 
     List<EventResponse> getAllEvent();
 
-    EventPagingResult getAllEventByPaging(int page, int count);
+    EventPagingResponse getAllEventByPaging(int page, int count);
 }

--- a/src/main/java/seoultech/startapp/plan/adapter/in/PlanAuthController.java
+++ b/src/main/java/seoultech/startapp/plan/adapter/in/PlanAuthController.java
@@ -29,7 +29,7 @@ class PlanAuthController {
     private final PlanRemoveUseCase planRemoveUseCase;
     private final PlanRegisterUseCase planRegisterUseCase;
 
-    @GetMapping("")
+    @GetMapping("/list")
     public ResponseEntity<?> getPlanByPaging(@RequestParam int page, @RequestParam(required = false,defaultValue = "10") int count){
 
         PlanPagingResponse allPlanByPaging = planGetUseCase.getAllPlanByPaging(page,count);

--- a/src/main/java/seoultech/startapp/plan/application/PlanPagingResponse.java
+++ b/src/main/java/seoultech/startapp/plan/application/PlanPagingResponse.java
@@ -13,5 +13,5 @@ public class PlanPagingResponse {
 
     private int totalPage;
 
-    private List<PlanResponse> pageList;
+    private List<PlanResponse> planList;
 }

--- a/src/test/java/seoultech/startapp/event/application/EventGetServiceTest.java
+++ b/src/test/java/seoultech/startapp/event/application/EventGetServiceTest.java
@@ -102,7 +102,7 @@ class EventGetServiceTest {
         when(loadEventPort.loadAllEventByPaging(pageRequest))
             .thenReturn(eventPage);
 
-        EventPagingResult allEventByPaging = eventGetService.getAllEventByPaging(PAGE,COUNT);
+        EventPagingResponse allEventByPaging = eventGetService.getAllEventByPaging(PAGE, COUNT);
 
         assertThat(allEventByPaging.getTotalPage()).isEqualTo(pageResult.get("totalPage"));
     }


### PR DESCRIPTION
# PageList

기존의 PlanPagingResponse와 EventPagingResponse에
페이징 결과의 네이밍이 `pageList`로 되어 있어서 `PlanList, eventList`로 각각 변경 해줌

# Plan API 수정
기존 plan Paging API
`/api/admin/plan?page=0&count=10` 에서
새로운 plan Paging API
`/api/admin/plan/list?page=0&count=10`으로 변경

# EventPagingResult

기존 `EventPagingResult `class 이름을
`EventPagingResponse` 로 바꿈