### PR TITLE
Feat: error logging 추가

### DIFF
--- a/src/main/java/seoultech/startapp/global/common/ErrorLogDto.java
+++ b/src/main/java/seoultech/startapp/global/common/ErrorLogDto.java
@@ -1,0 +1,38 @@
+package seoultech.startapp.global.common;
+
+import lombok.Builder;
+import lombok.Getter;
+@Getter
+public class ErrorLogDto {
+
+  private String requestMethod;
+  private String requestUrl;
+  private String errorType;
+  private String errorMessage;
+
+  private int statusCode;
+  private String requestBody;
+
+  @Builder
+  public ErrorLogDto(String requestMethod, String requestUrl, String errorType,
+      String errorMessage, int statusCode, String requestBody) {
+    this.requestMethod = requestMethod;
+    this.requestUrl = requestUrl;
+    this.errorType = errorType;
+    this.errorMessage = errorMessage;
+    this.statusCode = statusCode;
+    this.requestBody = requestBody;
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorLogDto{" +
+        "requestMethod='" + requestMethod + '\'' +
+        ", requestUrl='" + requestUrl + '\'' +
+        ", errorType='" + errorType + '\'' +
+        ", errorMessage='" + errorMessage + '\'' +
+        ", statusCode=" + statusCode +
+        ", requestBody='" + requestBody + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/seoultech/startapp/global/common/ErrorLoggerHelper.java
+++ b/src/main/java/seoultech/startapp/global/common/ErrorLoggerHelper.java
@@ -1,0 +1,56 @@
+package seoultech.startapp.global.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import seoultech.startapp.global.exception.ErrorType;
+
+@Slf4j
+@Component
+public class ErrorLoggerHelper {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public void log(ContentCachingRequestWrapper request, ErrorType errorType, String mesasge)
+      throws IOException {
+    ErrorLogDto errorLogDto = toErrorLog(request, errorType, mesasge);
+    log.error(objectMapper.writeValueAsString(errorLogDto));
+  }
+
+  private ErrorLogDto toErrorLog(ContentCachingRequestWrapper request, ErrorType errorType,
+      String mesasge)
+      throws IOException {
+    return ErrorLogDto.builder()
+        .requestMethod(request.getMethod())
+        .requestUrl(request.getRequestURI())
+        .errorMessage(mesasge)
+        .errorType(errorType.getErrorType())
+        .statusCode(errorType.getStatusCode())
+        .requestBody(getRequestBody(request))
+        .build();
+  }
+
+  private String getRequestBody(ContentCachingRequestWrapper request) throws IOException {
+    if (isReadableRequestBody(request)) {
+      return new String(request.getContentAsByteArray());
+    }
+    return null;
+  }
+
+  private boolean isReadableRequestBody(ContentCachingRequestWrapper request) {
+    String method = request.getMethod().toUpperCase();
+    String contentType = request.getContentType();
+    if(contentType == null){
+      return false;
+    }
+    /*
+     *  POST ,PUT, application-json 방식만 허용.
+     */
+    if (method.startsWith("P") && contentType.equalsIgnoreCase("application/json")) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/seoultech/startapp/global/config/security/JwtExceptionFilter.java
+++ b/src/main/java/seoultech/startapp/global/config/security/JwtExceptionFilter.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import seoultech.startapp.global.common.ErrorLoggerHelper;
 import seoultech.startapp.global.exception.BusinessException;
 import seoultech.startapp.global.exception.ErrorType;
 import seoultech.startapp.global.response.FailResponse;
@@ -21,21 +23,22 @@ import seoultech.startapp.global.response.FailResponse;
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
-
+  private final ErrorLoggerHelper errorLoggerHelper;
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    log.info("["+request.getMethod()+"] "+ request.getRequestURI() );
+    ContentCachingRequestWrapper wrapper = new ContentCachingRequestWrapper(request);
     try{
       filterChain.doFilter(request,response);
     }catch (BusinessException e ){
       ErrorType errorType = e.getErrorType();
+      errorLoggerHelper.log(wrapper,errorType,e.getMessage());
       responseHandle(response, errorType, e.getMessage());
     }catch (Exception e) {
+      errorLoggerHelper.log(wrapper,ErrorType.INTERNAL_SERVER_ERROR,"서버 에러");
       responseHandle(response,ErrorType.INTERNAL_SERVER_ERROR, "서버에러");
     }
   }
-
 
   private void responseHandle(HttpServletResponse response, ErrorType errorType, String message)
       throws IOException {

--- a/src/main/java/seoultech/startapp/global/config/security/SecurityConfig.java
+++ b/src/main/java/seoultech/startapp/global/config/security/SecurityConfig.java
@@ -20,7 +20,6 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 

--- a/src/main/java/seoultech/startapp/global/config/web/WebConfig.java
+++ b/src/main/java/seoultech/startapp/global/config/web/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.CommonsRequestLoggingFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -27,7 +28,7 @@ public class WebConfig implements WebMvcConfigurer {
     loggingFilter.setIncludeQueryString(true);
     loggingFilter.setIncludePayload(true);
     loggingFilter.setIncludeHeaders(false);
-    loggingFilter.setMaxPayloadLength(1024* 1024);
+    loggingFilter.setMaxPayloadLength(1024 * 1024);
     FilterRegistrationBean bean = new FilterRegistrationBean(loggingFilter);
     return bean;
   }

--- a/src/main/java/seoultech/startapp/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/seoultech/startapp/global/exception/GlobalExceptionHandler.java
@@ -1,40 +1,55 @@
 package seoultech.startapp.global.exception;
 
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import seoultech.startapp.global.common.ErrorLoggerHelper;
 import seoultech.startapp.global.response.JsonResponse;
 
 import javax.validation.ConstraintViolationException;
 
 @Slf4j
 @ControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+  private final ErrorLoggerHelper errorLoggerHelper;
+
   @ExceptionHandler(BusinessException.class)
-  public ResponseEntity<?> handleBusinessException(BusinessException e) {
+  public ResponseEntity<?> handleBusinessException(BusinessException e,
+      ContentCachingRequestWrapper requestWrapper)
+      throws IOException {
     ErrorType error = e.getErrorType();
+    errorLoggerHelper.log(requestWrapper, error, e.getMessage());
     return JsonResponse.fail(error, e.getMessage());
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
-  public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
+  public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e,
+      ContentCachingRequestWrapper requestWrapper) throws IOException {
+    errorLoggerHelper.log(requestWrapper, ErrorType.INVALID_INPUT, e.getMessage());
     return JsonResponse.fail(ErrorType.INVALID_INPUT, "잘못된 값입니다.");
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<?> internalServerException(Exception e) {
-    e.printStackTrace();
+  public ResponseEntity<?> internalServerException(Exception e,
+      ContentCachingRequestWrapper requestWrapper) throws IOException {
+    System.out.println(e.getMessage());
+    errorLoggerHelper.log(requestWrapper, ErrorType.INTERNAL_SERVER_ERROR, e.getMessage());
     return JsonResponse.fail(ErrorType.INTERNAL_SERVER_ERROR, "서버 에러");
   }
 
   @ExceptionHandler(value = {HttpMessageNotReadableException.class,
       HttpRequestMethodNotSupportedException.class})
-  public ResponseEntity<?> handleDateTimeFormatException(HttpMessageNotReadableException e) {
-    e.printStackTrace();
+  public ResponseEntity<?> handleDateTimeFormatException(HttpMessageNotReadableException e,
+      ContentCachingRequestWrapper requestWrapper) throws IOException {
+    errorLoggerHelper.log(requestWrapper, ErrorType.INVALID_INPUT, e.getMessage());
     return JsonResponse.fail(ErrorType.INVALID_INPUT, "잘못된 요청입니다.");
   }
 }


### PR DESCRIPTION
- Error Log Dto를 만들어서 실제 log를 json형식의 String으로 찍음.
- Request Method, RequestURI, errorType(ex ST001),  errorMessage => 비지니스 에러는 개발자가 직접 작성한 에러메시지, 그 외는 시스템이 만드는 에러 (ex Content type 'text/plain;charset=UTF-8' not supported), requestBody => POST,PUT, content-type이 application/json만 출력

### 적용 대상
- JWT Exception Filter, 
- GlobalExceptionHandler

Closes #83 