### PR TITLE
Fix:Sms 인증 확인시 마지막 번호만 가져오게 구현

### DIFF
--- a/src/main/java/seoultech/startapp/member/adapter/out/JpaSmsAuthRepository.java
+++ b/src/main/java/seoultech/startapp/member/adapter/out/JpaSmsAuthRepository.java
@@ -8,4 +8,5 @@ public interface JpaSmsAuthRepository extends JpaRepository<JpaSmsAuth, Long> {
 
   Long countBySmsTimeAfterAndPhoneNo(LocalDateTime smsTime, String phoneNo);
   Optional<JpaSmsAuth> findByAuthCodeAndPhoneNo(String authCode, String phoneNo);
+  Optional<JpaSmsAuth> findFirstByPhoneNoOrderByIdDesc(String phoneNo);
 }

--- a/src/main/java/seoultech/startapp/member/adapter/out/SmsAuthPersistenceAdapter.java
+++ b/src/main/java/seoultech/startapp/member/adapter/out/SmsAuthPersistenceAdapter.java
@@ -21,8 +21,8 @@ public class SmsAuthPersistenceAdapter implements LoadSmsAuthPort, SaveSmsAuthPo
   }
 
   @Override
-  public SmsAuth loadByPhoneNoAndCode(String phoneNo, String code) {
-    return jpaSmsAuthRepository.findByAuthCodeAndPhoneNo(code,phoneNo)
+  public SmsAuth loadLastAuthByPhoneNo(String phoneNo) {
+    return jpaSmsAuthRepository.findFirstByPhoneNoOrderByIdDesc(phoneNo)
         .map(smsAuthMapper::toDomainEntity)
         .orElse(null);
   }

--- a/src/main/java/seoultech/startapp/member/application/SmsAuthService.java
+++ b/src/main/java/seoultech/startapp/member/application/SmsAuthService.java
@@ -74,14 +74,18 @@ public class SmsAuthService implements SmsAuthUseCase {
   @Override
   public void findPasswordCheck(FindPasswordCheckCommand command) {
     Member member = loadMemberPort.loadByStudentNo(command.getStudentNo());
-    SmsAuth smsAuth = loadSmsAuthPort.loadByPhoneNoAndCode(member.getProfile().getPhoneNo(),
-        command.getCode());
 
-    if (smsAuth == null) {
+    SmsAuth auth = loadSmsAuthPort.loadLastAuthByPhoneNo(member.getProfile().getPhoneNo());
+
+    if (auth == null) {
       throw new NotMatchPhoneAuthException("인증 정보가 일치하지 않습니다.");
     }
 
-    smsAuth.validTime(LocalDateTime.now());
+    if(!auth.getAuthCode().equals(command.getCode())){
+      throw new NotMatchPhoneAuthException("인증 정보가 일치하지 않습니다.");
+    }
+
+    auth.validTime(LocalDateTime.now());
     redisCachePort.setStringWithTTL("PASSWORD-" + command.getStudentNo(), command.getCode(), 5,
         TimeUnit.MINUTES);
   }
@@ -91,12 +95,17 @@ public class SmsAuthService implements SmsAuthUseCase {
   public void check(SmsCheckCommand command) {
     String phoneNo = command.getPhoneNo();
     String code = command.getCode();
-    SmsAuth smsAuth = loadSmsAuthPort.loadByPhoneNoAndCode(phoneNo, code);
-    if (smsAuth == null) {
+    SmsAuth auth = loadSmsAuthPort.loadLastAuthByPhoneNo(command.getPhoneNo());
+
+    if (auth == null) {
       throw new NotMatchPhoneAuthException("인증 정보가 일치하지 않습니다.");
     }
 
-    smsAuth.validTime(LocalDateTime.now());
+    if (!auth.getAuthCode().equals(command.getCode())){
+      throw new NotMatchPhoneAuthException("인증 정보가 일치하지 않습니다.");
+    }
+
+    auth.validTime(LocalDateTime.now());
 
     redisCachePort.setStringWithTTL("PHONE-" + phoneNo, code, 5, TimeUnit.MINUTES);
   }

--- a/src/main/java/seoultech/startapp/member/application/port/out/LoadSmsAuthPort.java
+++ b/src/main/java/seoultech/startapp/member/application/port/out/LoadSmsAuthPort.java
@@ -5,5 +5,5 @@ import seoultech.startapp.member.domain.SmsAuth;
 public interface LoadSmsAuthPort {
 
   Long countByTenMin(String phoneNo);
-  SmsAuth loadByPhoneNoAndCode(String phoneNo, String code);
+  SmsAuth loadLastAuthByPhoneNo(String phoneNo);
 }

--- a/src/test/java/seoultech/startapp/member/application/SmsAuthServiceTest.java
+++ b/src/test/java/seoultech/startapp/member/application/SmsAuthServiceTest.java
@@ -102,10 +102,21 @@ class SmsAuthServiceTest {
   @Test
   @DisplayName("인증 확인시 저장된 정보가 없음.")
   public void sms_check_fail_not_saveAuth() throws Exception {
-    given(loadSmsAuthPort.loadByPhoneNoAndCode(any(), any())).willReturn(null);
+    given(loadSmsAuthPort.loadLastAuthByPhoneNo(any())).willReturn(null);
 
     assertThrows(NotMatchPhoneAuthException.class, () ->
         smsAuthService.check(smsCheckCommand));
+  }
+
+  @Test
+  @DisplayName("인증 코드와 마지막 인증 저장된 코드가 불일치한 경우 실패")
+  public void sms_check_fail_not_match() throws Exception {
+    SmsAuth notMatchCodeAuth = SmsAuth.builder()
+        .authCode("0000000")
+        .build();
+    given(loadSmsAuthPort.loadLastAuthByPhoneNo(any())).willReturn(notMatchCodeAuth);
+
+    assertThrows(NotMatchPhoneAuthException.class,()-> smsAuthService.check(smsCheckCommand));
   }
 
   @Test
@@ -116,7 +127,7 @@ class SmsAuthServiceTest {
         .authCode("123456")
         .smsTime(LocalDateTime.now().minusMinutes(4))
         .build();
-    given(loadSmsAuthPort.loadByPhoneNoAndCode(any(), any())).willReturn(expiredAuth);
+    given(loadSmsAuthPort.loadLastAuthByPhoneNo(any())).willReturn(expiredAuth);
 
     assertThrows(ExpiredPhoneAuthCodeException.class, () ->
         smsAuthService.check(smsCheckCommand));
@@ -127,10 +138,10 @@ class SmsAuthServiceTest {
   public void sms_check_success() throws Exception {
     SmsAuth expiredAuth = SmsAuth.builder()
         .smsAuthId(1L)
-        .authCode("123456")
+        .authCode(smsCheckCommand.getCode())
         .smsTime(LocalDateTime.now().minusMinutes(2))
         .build();
-    given(loadSmsAuthPort.loadByPhoneNoAndCode(any(), any())).willReturn(expiredAuth);
+    given(loadSmsAuthPort.loadLastAuthByPhoneNo(any())).willReturn(expiredAuth);
 
     smsAuthService.check(smsCheckCommand);
 
@@ -180,8 +191,9 @@ class SmsAuthServiceTest {
         .build();
 
     given(loadMemberPort.loadByStudentNo("studentNo")).willReturn(member);
-    given(loadSmsAuthPort.loadByPhoneNoAndCode(any(), any())).willReturn(SmsAuth.builder()
+    given(loadSmsAuthPort.loadLastAuthByPhoneNo(any())).willReturn(SmsAuth.builder()
             .smsAuthId(1L)
+            .authCode(findPasswordCheckCommand.getCode())
             .phoneNo("010-2642-2713")
             .smsTime(LocalDateTime.now().minusMinutes(1))
         .build());


### PR DESCRIPTION
### 문제점
- 기존 로직에서 code와 phone 2개로 DB에서 찾아서 Check 하는 로직
- 즉 기간 만료된거만 확인을 함.

### 변경점
- findFirstByPhoneNoOrderByIdDesc
- phoneNo로 Id Desc(내림차순) -> 마지막 id를  1개 찾아옴(First)
- 해당 번호의 code와 요청 보낸 코드가 일치하는지 체크로 변경